### PR TITLE
bugfix/accurics_remediation_13005324176854516 - Auto Generated Pull Request From Accurics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,25 +23,30 @@ resource "aws_s3_bucket" "b" {
     Name        = "My bucket"
     Environment = "Dev"
   }
+
+  versioning {
+    enabled    = true
+    mfa_delete = true
+  }
 }
 
 resource "aws_s3_bucket" "my-github-actions-bucket1979" {
-  bucket =  "my-github-actions-bucket1979"
-  acl = "public-read"
+  bucket = "my-github-actions-bucket1979"
+  acl    = "public-read"
 
-#  server_side_encryption_configuration {
-#   rule {
-#     apply_server_side_encryption_by_default {
-#       sse_algorithm = "AES256"
-#     }
-#   }
-# }
+  #  server_side_encryption_configuration {
+  #   rule {
+  #     apply_server_side_encryption_by_default {
+  #       sse_algorithm = "AES256"
+  #     }
+  #   }
+  # }
 
   tags = {
-    Name = "GitHubActions"
+    Name        = "GitHubActions"
     Environment = "Dev"
   }
-  
+
 }
 resource "aws_instance" "app_server" {
   count         = 2 # Will create 2 EC2 instances
@@ -51,7 +56,7 @@ resource "aws_instance" "app_server" {
   tags = {
     Tenable     = "FA"
     Environment = "Dev"
-    Name = "Compute"
+    Name        = "Compute"
   }
 }
 
@@ -60,32 +65,32 @@ resource "aws_security_group" "allow_ssh_dev_access2" {
   description = "Allow SSH access by Development Team"
   vpc_id      = "vpc-5bcd7721"
 
-  ingress = [ {
-    cidr_blocks = [ "0.0.0.0/0" ]
+  ingress = [{
+    cidr_blocks = ["0.0.0.0/0"]
     #cidr_blocks = [ "10.0.0.0/8" ]
-    description = "Allow SSH Access from Dev"
-    from_port = 22
+    description      = "Allow SSH Access from Dev"
+    from_port        = 22
     ipv6_cidr_blocks = []
-    prefix_list_ids = []
-    protocol = "tcp"
-    security_groups = []
-    self = false
-    to_port = 22
-  } ]
+    prefix_list_ids  = []
+    protocol         = "tcp"
+    security_groups  = []
+    self             = false
+    to_port          = 22
+  }]
 
-  egress = [ {
-    cidr_blocks = [ "0.0.0.0/0" ]
-    description = "Allow All Outbound"
-    from_port = 0
+  egress = [{
+    cidr_blocks      = ["0.0.0.0/0"]
+    description      = "Allow All Outbound"
+    from_port        = 0
     ipv6_cidr_blocks = ["::/0"]
-    prefix_list_ids = []
-    protocol = "-1"
-    security_groups = []
-    self = false
-    to_port = 0
-  } ]
-  
+    prefix_list_ids  = []
+    protocol         = "-1"
+    security_groups  = []
+    self             = false
+    to_port          = 0
+  }]
+
   tags = {
     Name = "allow_ssh2"
   }
-  }
+}


### PR DESCRIPTION
Perform the steps below to enable MFA delete on an S3 bucket.

Note:
-You cannot enable MFA Delete using the AWS Management Console. You must use the AWS CLI or API.
-You must use your 'root' account to enable MFA Delete on S3 buckets.

**From Command line:**

1. Run the s3api put-bucket-versioning command

```
aws s3api put-bucket-versioning --profile my-root-profile --bucket Bucket_Name --versioning-configuration Status=Enabled,MFADelete=Enabled --mfa “arn:aws:iam::aws_account_id:mfa/root-account-mfa-device passcode”
```.