### PR TITLE
bugfix/accurics_remediation_9687939094037048 - Auto Generated Pull Request From Accurics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,22 +26,22 @@ resource "aws_s3_bucket" "b" {
 }
 
 resource "aws_s3_bucket" "my-github-actions-bucket1979" {
-  bucket =  "my-github-actions-bucket1979"
-  acl = "public-read"
+  bucket = "my-github-actions-bucket1979"
+  acl    = "public-read"
 
-#  server_side_encryption_configuration {
-#   rule {
-#     apply_server_side_encryption_by_default {
-#       sse_algorithm = "AES256"
-#     }
-#   }
-# }
+  #  server_side_encryption_configuration {
+  #   rule {
+  #     apply_server_side_encryption_by_default {
+  #       sse_algorithm = "AES256"
+  #     }
+  #   }
+  # }
 
   tags = {
-    Name = "GitHubActions"
+    Name        = "GitHubActions"
     Environment = "Dev"
   }
-  
+
 }
 resource "aws_instance" "app_server" {
   count         = 2 # Will create 2 EC2 instances
@@ -51,7 +51,12 @@ resource "aws_instance" "app_server" {
   tags = {
     Tenable     = "FA"
     Environment = "Dev"
-    Name = "Compute"
+    Name        = "Compute"
+  }
+
+  metadata_options {
+    http_endpoint = "disabled"
+    http_tokens   = "required"
   }
 }
 
@@ -60,32 +65,32 @@ resource "aws_security_group" "allow_ssh_dev_access2" {
   description = "Allow SSH access by Development Team"
   vpc_id      = "vpc-5bcd7721"
 
-  ingress = [ {
-    cidr_blocks = [ "0.0.0.0/0" ]
+  ingress = [{
+    cidr_blocks = ["0.0.0.0/0"]
     #cidr_blocks = [ "10.0.0.0/8" ]
-    description = "Allow SSH Access from Dev"
-    from_port = 22
+    description      = "Allow SSH Access from Dev"
+    from_port        = 22
     ipv6_cidr_blocks = []
-    prefix_list_ids = []
-    protocol = "tcp"
-    security_groups = []
-    self = false
-    to_port = 22
-  } ]
+    prefix_list_ids  = []
+    protocol         = "tcp"
+    security_groups  = []
+    self             = false
+    to_port          = 22
+  }]
 
-  egress = [ {
-    cidr_blocks = [ "0.0.0.0/0" ]
-    description = "Allow All Outbound"
-    from_port = 0
+  egress = [{
+    cidr_blocks      = ["0.0.0.0/0"]
+    description      = "Allow All Outbound"
+    from_port        = 0
     ipv6_cidr_blocks = ["::/0"]
-    prefix_list_ids = []
-    protocol = "-1"
-    security_groups = []
-    self = false
-    to_port = 0
-  } ]
-  
+    prefix_list_ids  = []
+    protocol         = "-1"
+    security_groups  = []
+    self             = false
+    to_port          = 0
+  }]
+
   tags = {
     Name = "allow_ssh2"
   }
-  }
+}


### PR DESCRIPTION
In AWS Console - 
1. When launching a new instance in the Amazon EC2 console, select the following options on the Configure Instance Details page:
    a. Under Advanced Details, for Metadata accessible, select Enabled.
    b. For Metadata version, select V2.

In Terraform -
1. For the aws_instance resource, set the metadata_options.http_endpoint field to disabled.
2. Set the metadata_options.http_tokens field to required.

References:
[https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/configuring-instance-metadata-service.html](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/configuring-instance-metadata-service.html)
[https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/instance#metadata_options](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/instance#metadata_options)